### PR TITLE
HPCC Installed, Readme updated.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,13 @@ RUN sudo apt-get install -y software-properties-common python-software-propertie
 # we'll need wget to fetch the key...
 RUN sudo apt-get install -y wget
 
+RUN wget http://cdn.hpccsystems.com/releases/CE-Candidate-5.2.4/bin/platform/hpccsystems-platform-community_5.2.4-1trusty_amd64.deb
+RUN sudo apt-get install -y g++ gcc make cmake bison flex binutils-dev libldap2-dev libcppunit-dev libicu-dev libxslt1-dev zlib1g-dev libboost-regex-dev libssl-dev libarchive-dev python2.7-dev libv8-dev openjdk-6-jdk libapr1-dev libaprutil1-dev libiberty-dev libhiredis-dev libtbb-dev default-jdk nodejs git expect zip
+RUN dpkg -i hpccsystems-platform-community_5.2.4-1trusty_amd64.deb
+RUN /etc/init.d/hpcc-init start; exit 0
+
 # Clean up APT when done.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+EXPOSE 8010 8002
+VOLUME [ "/var/log/HPCCSystems/" ]

--- a/README.md
+++ b/README.md
@@ -11,9 +11,35 @@ The container doesn't have a database server configured. It should be fairly eas
 
 ## Usage
 
-First, verify it works:
+First, start up the container:
 
-    # docker build -t hpcc .
-    # docker run -t -p 80 hpcc
+    $ docker build -t hpcc .
+    $ docker run -d -P --name hpcc hpcc
 
-This will expose port 80 within the container, you should run `docker ps` to check the port equivalent on the host machine and go to http://localhost:{EXPOSED_PORT} to confirm you get the proverbial "Hello, world!" message.
+Now check the port mappings for ECL Watch and ESP.
+
+    $ docker port hpcc
+    8002/tcp -> 0.0.0.0:32775
+    8010/tcp -> 0.0.0.0:32774
+
+Find out the ip of your docker machine.
+
+    $ docker-machine ip default
+    192.168.99.100
+
+You should now be able to hit http://<machine ip>:<exposed port>/ for both
+ECL Watch and ESP.
+
+## TODO / BUGS
+
+* HPCC is not always running after starting up docker.
+
+      `$ docker exec hpcc /etc/init.d/hpcc-init start`
+
+* The apt-get list in the docker file needs to be slimmed down.
+That's actually the list of dependencies to build HPCC, not run it.
+
+* The VOLUMEs don't seem to mount.
+
+* THOR doesn't currently start.  This isn't related to Docker though
+  as we've had this problem on other Ubuntu installs.


### PR DESCRIPTION
I did this in a few minutes for a friend so it's not perfect, but thought you might be interested.

Current issues:

* HPCC is not always running after starting up docker.

      `$ docker exec hpcc /etc/init.d/hpcc-init start`

* The apt-get list in the docker file needs to be slimmed down.
That's actually the list of dependencies to build HPCC, not run it.

* The VOLUMEs don't seem to mount.

* THOR doesn't currently start.  This isn't related to Docker though
  as we've had this problem on other ubuntu installs.